### PR TITLE
chore: switch from circle to github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v4
+        with:
+          cache: yarn
+          node-version-file: package.json
+      - run: yarn --immutable
+      - run: yarn tsc
+      - run: yarn lint --max-warnings=0
+      - run: yarn test --coverage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# NTID [![Circle CI](https://circleci.com/gh/exponent/ntid.svg?style=svg)](https://circleci.com/gh/exponent/ntid)
+# NTID
+
+[![tests](https://github.com/expo/ntid/workflows/tests/badge.svg)](https://github.com/expo/ntid/actions?query=workflow%3Atests)
 
 NTIDs are IDs of the form `Type[...]` where the string between the square brackets may contain other NTIDs or a URL-safe Base64 string. NTIDs are designed to be:
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  node:
-    version: 'stable'


### PR DESCRIPTION
## Why

Continuation of #5. Just fix the tooling so that the changes I'm making will be tested in CI.

## Test plan

Inspect CI run. (not sure how to remove circle)