### PR TITLE
chore: bump version and fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NTID
 
-[![tests](https://github.com/expo/ntid/workflows/tests/badge.svg)](https://github.com/expo/ntid/actions?query=workflow%3Atests)
+[![tests](https://github.com/expo/ntid/workflows/tests/badge.svg?branch=master)](https://github.com/expo/ntid/actions?query=workflow%3Atests+branch%3Amaster)
 
 NTIDs are IDs of the form `Type[...]` where the string between the square brackets may contain other NTIDs or a URL-safe Base64 string. NTIDs are designed to be:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ntid",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Self-documenting IDs that can be generated in any environment",
   "bin": "build/cli.js",
   "main": "build/ntid.js",


### PR DESCRIPTION
## Why

Bump version ahead of publishing a new version containing most recent changes.

## Test plan

Inspect