### PR TITLE
chore: fix master branch name in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: tests
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Why

Noticed that the main branch name was incorrect in the workflow file. Update it.